### PR TITLE
feat(statuscolumn): add statuscolumn support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,16 @@ Requires Neovim >= 0.7
 
 ## About
 
-Feline is a Lua statusline plugin that prioritizes speed, customizability and
-minimalism. It's fast and never gets in your way. Feline only provides you with
-the necessary tools that you need to customize the statusline to your liking and
-avoids feature-bloat. It's also extremely customizable and allows you to
-configure it in any way you wish to. Feline also has reasonable defaults for
-those who don't want to configure things and just want a good out of the box
-experience.
+Feline is a Lua statusline, statuscolumn and winbar plugin that prioritizes
+speed, customizability and minimalism. It's fast and never gets in your way.
+Feline only provides you with the necessary tools that you need to configure
+these UI elements to your liking and avoids feature-bloat. It's also extremely
+customizable and allows you to configure it in any way you wish to. Feline also
+has reasonable defaults for those who don't want to configure things and just
+want a good out of the box experience.
 
 The author of `feline.nvim` has stepped down from maintaining this project. This
-fork aims to serve as the new home for this plugin per
+repository is the plugins new home as per
 [reddit discussion](https://www.reddit.com/r/neovim/comments/116av04/comment/j99m5hj/?context=3).
 
 ## Features
@@ -61,6 +61,7 @@ fork aims to serve as the new home for this plugin per
 - Minimalistic, only provides the bare minimum and allows the user to build
   their own components very easily.
 - Winbar support.
+- Statuscolumn support.
 
 ## Requirements
 
@@ -70,6 +71,7 @@ fork aims to serve as the new home for this plugin per
     in Neovim for more info)
 - Optional
   - Neovim v0.8 or greater - For winbar support
+  - Neovim v0.9 or greater - For statuscolumn support
   - [nvim-web-devicons](https://github.com/kyazdani42/nvim-web-devicons/) - For
     icon support
   - [A patched font](https://github.com/ryanoasis/nerd-fonts/) - For icon
@@ -187,8 +189,8 @@ require('feline').winbar.setup()
 ### Configuring Feline to fit your needs
 
 If the default configuration doesn't suit your needs, Feline provides plenty of
-customization options enabling you to build your statusline exactly how you
-want. The only prerequisite is knowing the basics of Lua. Refer to the
+customization options enabling you to configure everything exactly how you want.
+The only prerequisite is knowing the basics of Lua. Refer to the
 [USAGE](USAGE.md) documentation or use `:help feline.txt` inside Neovim to read
 the USAGE docs. Additionally, you may find it helpful to look at the community
 configurations.
@@ -199,9 +201,11 @@ configurations.
 
 #### Feline crashes or disappears for seemingly no reason
 
-This can be caused if you forget to remove your other statusline plugins after
-installing Feline. Make sure all other statusline plugins are removed before you
-install Feline, that should fix the issue.
+This can be caused by conflicting plugins modifying the winbar, statuscolumn or
+statusbar along with Feline. The statusline is a core piece of functionality of
+Feline and can't easily be disabled. However, the optional components can be. If
+another plugin is modifying any of these components, then do not enable them in
+Feline.
 
 ### Reporting issues or feature requests
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -778,6 +778,19 @@ winbar. Additionally, the default value of `force_inactive` for the winbar is
 `{}`, which means the winbar is never forced to use the inactive components
 table by default.
 
+## Statuscolumn
+
+Feline has support for statuscolumn, an experimental Neovim 0.9 feature that
+allows you to customize the statuscolumn in similar fashion to the statusline
+and winbar. Statuscolumn can be enabled and components configured using the
+`require('feline').statuscolumn.setup()` function. It works pretty much the same
+way as the [setup function](#setup-function) for the statusline. However, it
+only accepts the `components`, `conditional_components`, `force_inactive` and
+`disable` values, the other values are shared across all components.
+Additionally, the default value of `force_inactive` for the statuscolumn is
+`{}`, which means the statuscolumn is never forced to use the inactive
+components table by default.
+
 ## Utility functions
 
 Feline provides a few utility functions that allow you to customize or modify
@@ -822,6 +835,18 @@ Feline by default has some built-in providers to make your life easy. They are:
 | [`diagnostic_warnings`](#diagnostics) | Diagnostics warnings count                     |
 | [`diagnostic_hints`](#diagnostics)    | Diagnostics hints count                        |
 | [`diagnostic_info`](#diagnostics)     | Diagnostics info count                         |
+
+Statuscolumn providers:
+
+| Name          | Description                                    |
+| ------------- | ---------------------------------------------- |
+| `fold_column` | Fold column for currently drawn line           |
+| `line_number` | (relative) line number of currently drawn line |
+| `sign_column` | Sign column for currently drawn line           |
+
+The statuscolumn providers are minimal in their defaults and are meant to offer
+guidance on how one might begin t configure these components. See the
+`statuscolumn.lua` files for details.
 
 ### Vi-mode
 

--- a/lua/feline/default_components.lua
+++ b/lua/feline/default_components.lua
@@ -21,6 +21,16 @@ local M = {
             inactive = {},
         },
     },
+    statuscolumn = {
+        icons = {
+            active = {},
+            inactive = {},
+        },
+        noicons = {
+            active = {},
+            inactive = {},
+        },
+    },
 }
 
 M.statusline.icons.active[1] = {
@@ -417,6 +427,60 @@ M.winbar.noicons.inactive[1] = {
             fg = 'white',
             bg = 'NONE',
             style = 'bold',
+        },
+        icon = '',
+    },
+}
+
+M.statuscolumn.icons.active[1] = {
+    {
+        provider = 'line_number',
+        hl = {
+            fg = 'white',
+            bg = 'NONE',
+        },
+        icon = '',
+    },
+    {
+        provider = 'sign_column',
+        hl = {
+            fg = 'blue',
+            bg = 'NONE',
+        },
+        icon = '',
+    },
+    {
+        provider = 'fold_column',
+        hl = {
+            fg = 'red',
+            bg = 'NONE',
+        },
+        icon = '',
+    },
+}
+
+M.statuscolumn.noicons.active[1] = {
+    {
+        provider = 'line_number',
+        hl = {
+            fg = 'white',
+            bg = 'NONE',
+        },
+        icon = '',
+    },
+    {
+        provider = 'sign_column',
+        hl = {
+            fg = 'blue',
+            bg = 'NONE',
+        },
+        icon = '',
+    },
+    {
+        provider = 'fold_column',
+        hl = {
+            fg = 'red',
+            bg = 'NONE',
         },
         icon = '',
     },

--- a/lua/feline/defaults.lua
+++ b/lua/feline/defaults.lua
@@ -116,4 +116,20 @@ return {
             type = 'table',
         },
     },
+    statuscolumn = {
+        force_inactive = {
+            type = 'table',
+            default_value = {},
+        },
+        disable = {
+            type = 'table',
+            default_value = {},
+        },
+        components = {
+            type = 'table',
+        },
+        conditional_components = {
+            type = 'table',
+        },
+    },
 }

--- a/lua/feline/generator.lua
+++ b/lua/feline/generator.lua
@@ -614,7 +614,7 @@ function Generator:generate(is_active, maxwidth)
     end
 
     -- If statusline width is greater than maxwidth, begin the truncation process
-    if statusline_width > maxwidth then
+    if maxwidth and statusline_width > maxwidth then
         -- First, sort the component indices in ascending order of the priority of the components
         -- that the indices refer to
         table.sort(component_indices, function(first, second)
@@ -669,7 +669,7 @@ function Generator:generate(is_active, maxwidth)
 
     -- If statusline still doesn't fit within window, remove components with truncate_hide set to
     -- true until it does
-    if statusline_width > maxwidth then
+    if maxwidth and statusline_width > maxwidth then
         for _, indices in ipairs(component_indices) do
             local section, number = indices[1], indices[2]
             local component = sections[section][number]

--- a/lua/feline/providers/init.lua
+++ b/lua/feline/providers/init.lua
@@ -7,6 +7,7 @@ local provider_categories = {
     file = lazy_require('feline.providers.file'),
     lsp = lazy_require('feline.providers.lsp'),
     git = lazy_require('feline.providers.git'),
+    statuscolumn = lazy_require('feline.providers.statuscolumn'),
     custom = {},
 }
 
@@ -36,6 +37,10 @@ local get_provider_category = {
     diagnostic_warnings = 'lsp',
     diagnostic_hints = 'lsp',
     diagnostic_info = 'lsp',
+
+    fold_column = 'statuscolumn',
+    line_number = 'statuscolumn',
+    sign_column = 'statuscolumn',
 }
 
 -- Providers that have been loaded

--- a/lua/feline/providers/statuscolumn.lua
+++ b/lua/feline/providers/statuscolumn.lua
@@ -1,0 +1,19 @@
+local M = {}
+
+function M.fold_column()
+    -- %C - fold column for currently drawn line
+    return '%C'
+end
+
+function M.line_number()
+    -- %l - line number of currently drawn line
+    -- %r - relative line number of currently drawn line
+    return '%=%{v:relnum?v:relnum:v:lnum}'
+end
+
+function M.sign_column()
+    -- %s - sign column for currently drawn line
+    return '%=%s'
+end
+
+return M


### PR DESCRIPTION
This commit introduces support for configuring the new EXPERIMENTAL
Neovim statuscolumn setting.  The default providers are still minimal in
their implementation and include:

    - line number
    - fold column
    - sign column

The providers will be augmented to support more advanced settings.  But
users can still define their own providers following the same procedure
as for the statusline.
