### PR TITLE
Fix illegal character issue in feline.nvim generator.lua

### DIFF
--- a/lua/feline/generator.lua
+++ b/lua/feline/generator.lua
@@ -514,7 +514,13 @@ local function get_component_width(component_str)
         return 0
     end
 
-    return api.nvim_eval_statusline(component_str, { maxwidth = 0 }).width
+    local ok, result = pcall(api.nvim_eval_statusline, component_str, { maxwidth = 0 })
+
+    if not ok then
+        return 0
+    end
+
+    return result.width
 end
 
 function Generator:trigger_provider_update(winid, section_nr, component_nr)


### PR DESCRIPTION
Hi Freddie 👋🏽 

I hope you're doing well! I encountered a minor issue in Feline where an unexpected character ("< >") appears. After some investigation, I found that this issue specifically occurs with Java files. I made a quick fix that seems to work.

Consider the possibility of adding a function to handle such characters or providing a config option for customization. This could enhance the overall flexibility of Feline.

Cheers,
Raphael
