### PR TITLE
fix: remove check for termguicolors

### DIFF
--- a/lua/feline/init.lua
+++ b/lua/feline/init.lua
@@ -178,7 +178,7 @@ end
 
 function M.setup(config)
     -- Check if termguicolors is enabled
-    if not vim.o.termguicolors then
+    if not vim.o.termguicolors and vim.version().minor < 10 then
         api.nvim_err_writeln(
             "Feline needs 'termguicolors' to be enabled to work properly\n"
                 .. "Please do `:help 'termguicolors'` in Neovim for more information"


### PR DESCRIPTION
I just updated neovim to the latest commit on master, and there has been some changes regarding options and termguicolors lately. Now it is enabled by default if the terminal supports it. After this change, it looks like the option is not set immediately, making feline error on a check during setup.

<img width="601" alt="image" src="https://github.com/freddiehaddad/feline.nvim/assets/5160701/47726188-0789-4dda-b051-6a8bdadf03c3">

I feel like we don't need this check anymore since it is now enabled by default. I know it isn't in a stable release yet, but I don't think there is any downsides to removing this check already now.