### PR TITLE
feat(providers): line_percentage padding option

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -817,7 +817,7 @@ Feline by default has some built-in providers to make your life easy. They are:
 | ------------------------------------- | ---------------------------------------------- |
 | [`vi_mode`](#vi-mode)                 | Current vim mode                               |
 | [`position`](#position)               | Get line and column number of cursor           |
-| `line_percentage`                     | Current line percentage                        |
+| [`line_percentage`](#line-percentage) | Current line percentage                        |
 | [`scroll_bar`](#scroll-bar)           | Scroll bar that shows file progress            |
 | [`search_count`](#search-count)       | Search count for current search                |
 | `macro`                               | Shows macro being recorded                     |
@@ -921,6 +921,10 @@ respectively. For example:
 ```lua
 format = 'Ln {line}, Col {col}'
 ```
+
+### Line Percentage
+
+The `line_percentage` provider can take a `padding` which may be either `true` or `false`. The default is `false`.
 
 ### Scroll bar
 

--- a/lua/feline/providers/cursor.lua
+++ b/lua/feline/providers/cursor.lua
@@ -49,16 +49,19 @@ function M.position(_, opts)
     end
 end
 
-function M.line_percentage()
+function M.line_percentage(_, opts)
     local curr_line = api.nvim_win_get_cursor(0)[1]
     local lines = api.nvim_buf_line_count(0)
 
-    if curr_line == 1 then
+    if lines == 1 then
+        return 'All'
+    elseif curr_line == 1 then
         return 'Top'
     elseif curr_line == lines then
         return 'Bot'
     else
-        return string.format('%2d%%%%', math.ceil(curr_line / lines * 99))
+        local format = opts.padding and '%2d%%%%' or '%d%%%%'
+        return string.format(format, math.ceil(curr_line / lines * 99))
     end
 end
 


### PR DESCRIPTION
This PR adds the option to toggle padding for the `line_percentage` provider.

Also, it now displays "All" when the buffer only has a single line rather than the old "Top", this small change is to make the provider function more like the default neovim statusline.