### PR TITLE
fix(provider[search-count]): Use pcall when querying search count (#92)

### DIFF
--- a/lua/feline/providers/cursor.lua
+++ b/lua/feline/providers/cursor.lua
@@ -81,13 +81,13 @@ function M.search_count()
         return ''
     end
 
-    local result = vim.fn.searchcount { maxcount = 999, timeout = 250 }
-
-    if result.incomplete == 1 or next(result) == nil then
+    local ok, result = pcall(vim.fn.searchcount, { maxcount = 999, timeout = 250 })
+    if not ok or next(result) == nil or result.incomplete == 1 then
         return ''
     end
 
-    return string.format('[%d/%d]', result.current, math.min(result.total, result.maxcount))
+    local denominator = math.min(result.total, result.maxcount)
+    return string.format('[%d/%d]', result.current, denominator)
 end
 
 function M.macro()


### PR DESCRIPTION
Calling vim.fn.searchcount can fail resulting in a Vim:E54 error.  The
solution is to use a protected call and check for success.

Fixes (#92)
